### PR TITLE
Update python, pip, and setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,9 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 # Replace the default path for VCS dependencies
 ENV PIP_SRC /usr/local/src
 
-# Upgrade pip/setuptools to latest version with py2 support + other required packages
+# Upgrade pip/setuptools to latest version with py2 support
 RUN pip install pip==20.3.4 setuptools==44.1.1 \
-                nose pytest mock gunicorn
+                nose==1.3.7 pytest==3.0.7 mock==2.0.0 gunicorn==19.7.1
 
 # Install node packages
 RUN ln -s /usr/bin/nodejs /usr/bin/node \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.8
+FROM python:2.7.9
 
 # Set versions as environment variables so that they can be inspected later.
 ENV LESSC_VERSION=1.7.5 \
@@ -27,8 +27,10 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 
 # Replace the default path for VCS dependencies
 ENV PIP_SRC /usr/local/src
-# Upgrade pip and install Python packages
-RUN pip install -U pip && pip install nose pytest mock gunicorn
+
+# Upgrade pip/setuptools to latest version with py2 support + other required packages
+RUN pip install pip==20.3.4 setuptools==44.1.1 \
+                nose pytest mock gunicorn
 
 # Install node packages
 RUN ln -s /usr/bin/nodejs /usr/bin/node \

--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM jusbrasil/python-web:0.4
+FROM jusbrasil/python-web:0.5
 
 ONBUILD COPY requirements.txt /usr/src/app/
 ONBUILD RUN pip install -r requirements.txt


### PR DESCRIPTION
- Update the Python from 2.7.8 to 2.7.9 for fixing warning messages in builds regarding broken support for HTTPS and SNI.
- Update to latest versions of `pip` and `setuptools` with Python 2 support.
- Maintain same version for `nose`, `pytest`, `mock` and `gunicorn`.

Ref: https://github.com/jusbrasil/jusbrasil-webpy/pull/3835